### PR TITLE
Fix import case sensitivity and update MainScreen implementation; adj…

### DIFF
--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -1,6 +1,6 @@
 import 'package:go_router/go_router.dart';
 import 'package:wallet_app_task/router/route_names.dart';
-import 'package:wallet_app_task/screens/MainScreen.dart';
+import 'package:wallet_app_task/screens/main_screen.dart';
 
 class RouterClass {
   final router = GoRouter(
@@ -10,7 +10,7 @@ class RouterClass {
         path: "/",
         name: RouteNames.mainPage,
         builder: (context, state) {
-          return const Mainscreen();
+          return const MainScreen();
         },
       ),
     ],

--- a/lib/screens/main_pages/home_screen.dart
+++ b/lib/screens/main_pages/home_screen.dart
@@ -52,7 +52,7 @@ class _HomeScreenState extends State<HomeScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             Text(
-              "${balance.toStringAsFixed(2)}",
+              balance.toStringAsFixed(2),
               style: TextStyle(
                   fontSize: 32,
                   fontWeight: FontWeight.bold,
@@ -167,8 +167,7 @@ class _HomeScreenState extends State<HomeScreen> {
                       CircleAvatar(
                         radius: 40,
                         child: Icon(Icons.add,
-                            size: 50,
-                            color: AppColors.primaryBlack.withOpacity(0.5)),
+                            size: 50, color: AppColors.primaryBlack),
                       ),
                       const SizedBox(height: 10),
                       const Text(

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -6,14 +6,14 @@ import 'package:wallet_app_task/screens/main_pages/more_screen.dart';
 import 'package:wallet_app_task/screens/main_pages/wallet_screen.dart';
 import 'package:wallet_app_task/utils/colors.dart';
 
-class Mainscreen extends StatefulWidget {
-  const Mainscreen({super.key});
+class MainScreen extends StatefulWidget {
+  const MainScreen({super.key});
 
   @override
-  State<Mainscreen> createState() => _MainscreenState();
+  State<MainScreen> createState() => _MainScreenState();
 }
 
-class _MainscreenState extends State<Mainscreen> {
+class _MainScreenState extends State<MainScreen> {
   int _selectedIndex = 0;
 
   static const List<Widget> _pages = <Widget>[

--- a/lib/widgets/feature_card.dart
+++ b/lib/widgets/feature_card.dart
@@ -12,6 +12,7 @@ class FeatureCard extends StatelessWidget {
       padding: const EdgeInsets.all(15),
       margin: const EdgeInsets.all(8),
       decoration: BoxDecoration(
+        // ignore: deprecated_member_use
         color: featureCardData.color.withOpacity(0.2),
         borderRadius: BorderRadius.circular(20),
       ),


### PR DESCRIPTION
This pull request includes several changes aimed at improving code consistency, fixing naming conventions, and enhancing UI readability. The most important changes include renaming the `Mainscreen` class to `MainScreen` for consistency, updating file names to follow proper naming conventions, and refining UI elements for better clarity.

### Naming and Code Consistency:

* Renamed the `Mainscreen` class and its associated state class to `MainScreen` and `_MainScreenState`, respectively, ensuring consistency in naming conventions. (`lib/screens/MainScreen.dart` → `lib/screens/main_screen.dart`, [lib/screens/main_screen.dartL9-R16](diffhunk://#diff-bd133be018e34ae83777c8dc99e8d7b05d957eb227800110bdb4de0238b4c91bL9-R16))
* Updated the file import path in `lib/router/router.dart` to reflect the renamed `main_screen.dart` file. (`lib/router/router.dart`, [lib/router/router.dartL3-R3](diffhunk://#diff-959036b106cee02ed8c65f84409c40c69c2ab7d72a30fe5e48f9ab3f7dea32a4L3-R3))
* Fixed the usage of the renamed `MainScreen` class in the `RouterClass` to match the updated naming. (`lib/router/router.dart`, [lib/router/router.dartL13-R13](diffhunk://#diff-959036b106cee02ed8c65f84409c40c69c2ab7d72a30fe5e48f9ab3f7dea32a4L13-R13))

### UI Refinements:

* Removed the unnecessary string interpolation for `balance.toStringAsFixed(2)` in the `HomeScreen` widget to simplify the code. (`lib/screens/main_pages/home_screen.dart`, [lib/screens/main_pages/home_screen.dartL55-R55](diffhunk://#diff-0db1415ef464d83df7e46564196bc12dbebee659ae79f818c2ecebbd891a6ba0L55-R55))
* Updated the `CircleAvatar` widget in the `HomeScreen` to remove the opacity modifier on the icon color, improving visual clarity. (`lib/screens/main_pages/home_screen.dart`, [lib/screens/main_pages/home_screen.dartL170-R170](diffhunk://#diff-0db1415ef464d83df7e46564196bc12dbebee659ae79f818c2ecebbd891a6ba0L170-R170))

### Code Quality:

* Added a comment to suppress a lint warning for the use of a deprecated member in the `FeatureCard` widget, ensuring the code remains maintainable. (`lib/widgets/feature_card.dart`, [lib/widgets/feature_card.dartR15](diffhunk://#diff-c786294de0553809bfc9f6c7bf5574524ea1ca64d69e5b667ab893511fb6dc15R15))…ust balance display and feature card color